### PR TITLE
Monitor scraper status

### DIFF
--- a/.github/workflows/combined-scrape-merge.yml
+++ b/.github/workflows/combined-scrape-merge.yml
@@ -10,6 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 📅 Check if past stop date
+        run: |
+          STOP_DATE="2025-10-22"
+          CURRENT_DATE=$(date -u +%Y-%m-%d)
+          if [[ "$CURRENT_DATE" > "$STOP_DATE" ]]; then
+            echo "Current date ($CURRENT_DATE) is after stop date ($STOP_DATE). Stopping workflow."
+            exit 78  # Exit code 78 indicates neutral exit (not failure)
+          fi
+          echo "Current date ($CURRENT_DATE) is before or equal to stop date ($STOP_DATE). Continuing workflow."
+
       - name: 📥 Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Add a date-based stop condition to the scraper workflow to prevent it from running after October 22nd, 2025.

---
<a href="https://cursor.com/background-agent?bcId=bc-b15db0a4-fb1e-4c7d-9efe-f3b9114ff4b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b15db0a4-fb1e-4c7d-9efe-f3b9114ff4b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

